### PR TITLE
Add -Dbuildtype=release to meson options

### DIFF
--- a/org.freedesktop.LinuxAudio.Plugins.DISTRHO-Ports.json
+++ b/org.freedesktop.LinuxAudio.Plugins.DISTRHO-Ports.json
@@ -15,6 +15,9 @@
         {
             "name": "distrho-ports",
             "buildsystem": "meson",
+            "config-opts": [
+                "-Dbuildtype=release"
+            ],
             "post-install": [
                 "ln -sf vst $FLATPAK_DEST/lxvst",
                 "mv ${FLATPAK_DEST}/vst/Dexed.so ${FLATPAK_DEST}/vst/DISTRHO-Dexed.so",


### PR DESCRIPTION
Follow the [DISTRHO-Ports](https://github.com/DISTRHO/DISTRHO-Ports) install steps, and pass the `-Dbuildtype=release` option to Meson.
This fixes the performance issues with Vitalium.